### PR TITLE
Prevent malformed markup by stripping tags

### DIFF
--- a/src/Forms/GoogleSearchPreview.php
+++ b/src/Forms/GoogleSearchPreview.php
@@ -86,10 +86,10 @@ class GoogleSearchPreview extends LiteralField
     public function highlight($haystack, $needle)
     {
         if (!$needle) {
-            return $haystack;
+            return strip_tags($haystack);
         }
 
-        return preg_replace('/\b(' . $needle . ')\b/i', '<strong>$0</strong>', $haystack);
+        return preg_replace('/\b(' . $needle . ')\b/i', '<strong>$0</strong>', strip_tags($haystack));
     }
 
     /**


### PR DESCRIPTION
If there was a link present in the first paragraph it can cause issues with the previewer.